### PR TITLE
Fix CI build by dropping npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - run: npm install
+      - run: npm run build
       - run: npm test


### PR DESCRIPTION
## Summary
- remove the npm cache configuration which requires a lockfile
- add an explicit npm run build step before tests

## Testing
- not run (rely on CI)